### PR TITLE
Failproof project setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,9 @@ setup(
     author='Zillow Group A.I. team',
     author_email='luminaire-dev-oss@zillowgroup.com',
 
-    python_requires='>=3.6',
+    python_requires='>=3.6,<3.7',
     packages=find_packages(),
+    setup_requires=['numpy==1.17.0'],
     install_requires=install_requires,
 
     classifiers=[


### PR DESCRIPTION
I guess python 3.7 and later considered not supported (see https://github.com/zillow/luminaire/runs/1946332964)

On python 3.6 `pyramid-arima` wheel build will fail (but it will not affect the installation of dependency - just produce log noise) without a numpy installed,  but it looks like it's not required to actually have it as dependecy - see https://github.com/zillow/luminaire/pull/74

P.S.
https://pip.pypa.io/en/latest/reference/pip_install/#controlling-setup-requires
There is a warning about how dangerous to use this keyword, but i guess it's ok for such simple case
It's also used in https://github.com/zillow/luminaire/pull/77/