### PR TITLE
Remove unused pyramid-arima dependency

### DIFF
--- a/luminaire/model/lad_structural.py
+++ b/luminaire/model/lad_structural.py
@@ -230,9 +230,6 @@ class LADStructuralModel(BaseModel):
         :param bool include_holidays: Whether to consider holidays as exogenous
         :param list ift_matrix: A list of list All exogenous variables where the ith column is the inverse Fourier
         transformation of the time series with first i*2 most relevant frequencies
-        :param int train_len: Storing the length of the time series
-        :param int pred_len: Storing the length of the future time points to predict
-        :param bool arima_error: Storing whether there is any exception occurred in the auto_arima run
         :param list stepwise_fit: A list storing different model object
         :param bool optimize: Flag to identify whether called from hyperparameter optimization
         :param list x_pred: list storing exogenous variable corresponding to the time point to predict
@@ -252,8 +249,7 @@ class LADStructuralModel(BaseModel):
                 exog['fourier_feature'] = np.float64(np.real(fourier_exog[:, 0]))
 
         # This check is required due to a bug in statsmodel arima which inflates the predictions and std error
-        # for time series containing only 0's. Can be removed if fixed in a later version of statsmodel
-        # or pyramid
+        # for time series containing only 0's. TODO: Can be removed if fixed in a later version of statsmodels
         if np.count_nonzero(endog) == 0:
             idx_max = len(endog) // 2
             idx = int(np.random.randint(0, idx_max, 1)[0])

--- a/luminaire/tests/conftest.py
+++ b/luminaire/tests/conftest.py
@@ -70,6 +70,21 @@ def training_test_data():
     return data
 
 @pytest.fixture(scope='session')
+def training_test_data_zeroes():
+    """
+    Data with all zeroes to test lad structural training
+    """
+
+    data = pd.read_csv(get_data_path('daily_test_time_series.csv'))
+    data['index'] = pd.DatetimeIndex(data['index'])
+    data['raw'] = np.zeros_like(np.array(data['raw']))
+    data['interpolated'] = data['raw']
+    data = pd.DataFrame(data, columns=['index', 'raw', 'interpolated']).set_index('index')
+
+    return data
+
+
+@pytest.fixture(scope='session')
 def scoring_test_data():
     """
     Data with missing indexes to test lad structural training

--- a/luminaire/tests/test_models.py
+++ b/luminaire/tests/test_models.py
@@ -16,6 +16,18 @@ class TestLADStructural(object):
 
         assert success and isinstance(model, LADStructuralModel)
 
+    def test_lad_structural_training_zeroes(self, training_test_data_zeroes):
+
+        hyper_params = LADStructuralHyperParams(is_log_transformed=False, p=4, q=0).params
+        lad_struct_obj = LADStructuralModel(hyper_params, freq='D')
+        data_summary = {'ts_start': training_test_data_zeroes.first_valid_index(),
+                        'ts_end': training_test_data_zeroes.last_valid_index(),
+                        'is_log_transformed': False}
+        success, ts_end, model = lad_struct_obj.train(data=training_test_data_zeroes, **data_summary)
+
+        assert success and isinstance(model, LADStructuralModel)
+
+
     def test_lad_structural_scoring(self, scoring_test_data, lad_structural_model):
 
         pred_date_normal = scoring_test_data.index[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ numpy==1.17.0
 pandas==0.25.1
 pykalman==0.9.5
 pyramid==1.9.2
-pyramid-arima==0.6.2
 scipy==1.2.2
 statsmodels==0.10.1
 scikit-learn==0.19.1


### PR DESCRIPTION
It looks what pyramid-arima not used now and statsmodels used directly
If i'm wrong it can be safely bumped to `0.9` (last version using old naming)

I added test for ` This check is required due to a bug in statsmodel arima which inflates the predictions and std error`, it looks like it is still reproduced for new version of statsmodels, as removing corresponding condition - fails the test.