### PR TITLE
Run ci actions for multiple python versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -9,40 +9,48 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      max-parallel: 3
+      fail-fast: false
+      matrix:
+        python-version: ['3.6', '3.7', '3.8'] # 3.9 build currently failing
+    name: Build for python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v2
-
-    - name: Set up Python 3.6
+    - name: Set up python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
-
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
     - name: Cache Dependencies
       id: cache
       uses: actions/cache@v2
       with:
-        # This path is specific to Ubuntu
-        path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        # os independent path
+        path: ${{ env.pythonLocation }}
+        # Look to see if there is a cache hit for the corresponding python location and requirements file
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
 
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        # we need to build proper wheel for scikit-learn 0.19.2 on python 3.8
+        # cacheless run will be slow, but next ones will use wheel
+        # if we skip wheel build - scikit-learn will be build from source each time
+        # if is as slow as initial wheel build up but for every run
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install numpy==1.17.5 # scipy need numpy on wheel build step, using same from requirements.txt
+        python -m pip install scipy==1.2.3 # scikit-learn need numpy and scipy on wheel build step, using same from requirements.txt
+        python -m pip install flake8 pytest # test and linting dependencies
+        if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
 
     - name: Linting with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics || exit 1
+        flake8 . --select=E9,F63,F7,F82 --show-source || exit 1
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        echo "================================ Lint warnings =============================="
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Test with pytest
       run: |
-        python -m pytest
+        pytest

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,10 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Operating System :: OS Independent',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
The goal of this PR to unblock never versions of python with "small blood"

- Python 3.6: security fixes only, no bug fixes will be provided; End Of Life: 2021-12-23 (soon)
- Python 3.7: security fixes only, no bug fixes will be provided; End Of Life: 2023-06-27 (not much)
- Python 3.8: security fixes AND bug fixes will be provided; End Of Life: 2024-10 (probably humanity will fall at this point due to massive sun flare)
- Python 3.9  October 2025 https://www.python.org/dev/peps/pep-0596/#lifespan (supernova for sure wipes the planet clean of carbon life)

Things really get better after after merging PRs below as 3.6, 3.7 now using built in wheels, 3.7 seems to be unlocked already  👍🏻 

- https://github.com/zillow/luminaire/pull/74
- https://github.com/zillow/luminaire/pull/75
- https://github.com/zillow/luminaire/pull/76

 3.8 need to build wheel initially for scipy, thus build deps should be installed first, after that using wheel from cache
  
~~3.9~~ (fails to install scikit-learn completely)

Various runs

https://github.com/zillow/luminaire/runs/1974082747?check_suite_focus=true - checking linter works as expected 👍🏻 

https://github.com/zillow/luminaire/runs/1973251631?check_suite_focus=true - check better caching as described in  https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d

Note 3.8 install dependencies time is 18 min but wheels status `done`, instead of `DEPRECATION: scipy was installed using the legacy 'setup.py install' method, because a wheel could not be built for it.` as seen in https://github.com/zillow/luminaire/runs/1971165453?check_suite_focus=true  👍🏻 

https://github.com/zillow/luminaire/runs/1973424828?check_suite_focus=true - check next build using cache and deps for 3.8 is now 7s  👍🏻 

https://github.com/zillow/luminaire/runs/1973722601?check_suite_focus=true - 3.9 failure run

https://github.community/t/expected-waiting-for-status-to-be-reported/18001 - setting for checks should be adjusted - it's stuck now

