### PR TITLE
Force linter to fail ci check

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Linting with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics || exit 1
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 


### PR DESCRIPTION
`exit 1` will will called only if first flake8 will fail and return non zero code from script block immediately

Before last command of script block was evaluated and second flake8 invocation was always returning 0 because of flag passed