### PR TITLE
Support for python 3.7 for build and deploy

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.7'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.7'
 
     - name: Cache Dependencies
       id: cache

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.7'
 
     - name: Install dependencies
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ pandas==0.25.3
 pykalman==0.9.5
 scipy==1.2.3
 statsmodels==0.10.2
-scikit-learn==0.19.2
+scikit-learn==0.24.2
+decorator==5.1.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='luminaire',
-    version='0.2.4',
+    version='0.3.0.dev1',
 
     license='Apache License 2.0',
 
@@ -33,6 +33,7 @@ setup(
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Operating System :: OS Independent',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
Support for python 3.7 for build and deploy
- Major dependent packages are kept the same
- Just making sure the code is compatible with Python 3.7 as Python 3.6 is reaching End of Life
