### PR TITLE
Luminaire v4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Install Luminaire from [PyPI](https://pypi.org/project/luminaire/) using ``pip``
 pip install luminaire
 ```
 
+> **PLEASE READ**
+> 
+> We had to remove `bayesian-changepoint-detection` package from requirements due to deployment issues in pypi 
+> (the latest version of scipy is not supported by `bayesian-changepoint-detection` v0.2.dev1). This is a dependency
+> for Luminaire training and data exploration process. Until a proper resolution is applied, please manually install a 
+> compatible version of the package from github using the following script:
+> 
+> ```bash
+> pip install git+https://github.com/hildensia/bayesian_changepoint_detection@2dd95f5c1d028116899a842ccb3baa173f9d5be9#egg=bayesian-changepoint-detection
+> ```
+
 Import ``luminaire`` module in python 
 ```python
 import luminaire

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 changepy>=0.3.1
 hyperopt>=0.1.2
-numpy>=1.17.5
+numpy>=1.17.5, <=1.22.4
 pandas>=0.25.3
 pykalman>=0.9.5
 scipy>=1.6.0
 statsmodels>=0.13.0
 scikit-learn>=0.24.2
 decorator>=5.1.0
-py4j<=0.10.9.3

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='luminaire',
-    version='0.4.0.dev3',
+    version='0.4.0',
 
     license='Apache License 2.0',
 


### PR DESCRIPTION
Changes related to Luminaire 0.4.0 release.

Note: 
1. Observed build failure with numpy >= 1.23.0. I am going to create a separate issue for this. 
2. Py4j issue has been fixed in their latest release. Reference: https://github.com/py4j/py4j/issues/476