### PR TITLE
Related to issue #112: Exploration failure for weekly data

### DIFF
--- a/luminaire/exploration/data_exploration.py
+++ b/luminaire/exploration/data_exploration.py
@@ -124,8 +124,7 @@ class DataExploration(object):
             'D': 7,
         }
 
-        if freq in ['H', 'D']:
-            self.tc_window_length = tc_window_len_dict.get(freq)
+        self.tc_window_length = tc_window_len_dict.get(freq) if freq in ['H', 'D'] else None
 
         self.tc_max_window_length = 24
 


### PR DESCRIPTION
The current approach for trend turning was enabled only for daily and hourly time series. Added a quick fix to trigger computation of window sizes for other frequency types.