### PR TITLE
bug #112: window size identification fixed for trend change detection

### DIFF
--- a/luminaire/exploration/data_exploration.py
+++ b/luminaire/exploration/data_exploration.py
@@ -122,10 +122,10 @@ class DataExploration(object):
         tc_window_len_dict = {
             'H': 24,
             'D': 7,
+            'W':4
         }
 
-        if freq in ['H', 'D']:
-            self.tc_window_length = tc_window_len_dict.get(freq)
+        self.tc_window_length = tc_window_len_dict.get(freq) if freq in ['H', 'D', 'W'] else None
 
         self.tc_max_window_length = 24
 


### PR DESCRIPTION
The current approach for trend detection in the Data exploration module (`/luminaire/exploration/data_exploration.py`) was enabled only for **daily ('D')** and **hourly ('H)** time series. 
I added a fix to trigger the computation of window sizes for **weekly ('W')** frequency, using a value of 4.
Also, I added a fix to support all the other frequencies.

* This is related to issue [Weekly data exploration failure #112](https://github.com/zillow/luminaire/issues/112)

* This PR is to replace the PR [https://github.com/zillow/luminaire/pull/113](https://github.com/zillow/luminaire/pull/113)
