### PR TITLE
issue #110: bayescd dependency added in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@
 - [Quick Start](#quick-start)
 - [Time Series Outlier Detection Workflow](#time-series-outlier-detection-workflow)
 - [Anomaly Detection for High Frequency Time Series](#anomaly-detection-for-high-frequency-time-series)
+- [Examples](#examples)
 - [Contributing](#contributing)
-- [Acknowledgements](#acknowledgements)
+- [Citing](#citing)
+- [Other Useful Resources](#other-useful-resources)
+- [Blogs](#blogs)
 - [Development Team](#development-team)
 
 
@@ -35,17 +38,6 @@ Install Luminaire from [PyPI](https://pypi.org/project/luminaire/) using ``pip``
 ```bash
 pip install luminaire
 ```
-
-> **PLEASE READ**
-> 
-> We had to remove `bayesian-changepoint-detection` package from requirements due to deployment issues in pypi 
-> (the latest version of scipy is not supported by `bayesian-changepoint-detection` v0.2.dev1). This is a dependency
-> for Luminaire training and data exploration process. Until a proper resolution is applied, please manually install a 
-> compatible version of the package from github using the following script:
-> 
-> ```bash
-> pip install git+https://github.com/hildensia/bayesian_changepoint_detection@2dd95f5c1d028116899a842ccb3baa173f9d5be9#egg=bayesian-changepoint-detection
-> ```
 
 Import ``luminaire`` module in python 
 ```python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bayescd==0.4
 changepy>=0.3.1
 hyperopt>=0.1.2
 numpy>=1.17.5, <=1.22.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bayescd==0.4
+bayescd>=0.4
 changepy>=0.3.1
 hyperopt>=0.1.2
 numpy>=1.17.5, <=1.22.4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='luminaire',
-    version='0.4.0',
+    version='0.4.1',
 
     license='Apache License 2.0',
 


### PR DESCRIPTION
Manual installation is no more required for `bayesian-changepoint-detection` package. The package will now be installed via `bayescd` package from pypi