### PR TITLE
explicit installation of bayesian-changepoint-detection no longer needed

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,7 +34,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        pip install git+https://github.com/hildensia/bayesian_changepoint_detection@2dd95f5c1d028116899a842ccb3baa173f9d5be9#egg=bayesian-changepoint-detection
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Linting with flake8


### PR DESCRIPTION
What:
Leveraging https://pypi.org/project/bayescd now since its available via PyPI instead of explicitly installing bayesian-changepoint-detection in our ci/cd pipelines

Why:
We will end up installing the same package twice (via PyPI and explicitly) and will cause issues with test cases when our ci/cd pipelines are triggered. 

This will close issue https://github.com/zillow/luminaire/issues/119 