### PR TITLE
Diff order fix

### DIFF
--- a/luminaire/model/lad_filtering.py
+++ b/luminaire/model/lad_filtering.py
@@ -297,7 +297,7 @@ class LADFilteringModel(BaseModel):
                 actual_previous_per_diff = [interpolated_actual_previous[-1]] \
                     if diff_order == 1 else [interpolated_actual_previous[-1], np.diff(interpolated_actual_previous)[0]]
                 seq_tail = interpolated_actual_previous + [interpolated_actual]
-                interpolated_actual = np.diff(seq_tail, 2)[-1]
+                interpolated_actual = np.diff(seq_tail, diff_order)[-1]
 
             post_pred = prior_pred + kalman_gain[0][0] * (interpolated_actual - (observation_matrix[0][0] * prior_pred))
 

--- a/luminaire/tests/test_models.py
+++ b/luminaire/tests/test_models.py
@@ -193,3 +193,19 @@ class TestLADStructural(object):
         result = window_density_model_hourly_aggregated.score(data)
 
         assert result[0]['Success'] and isinstance(result[0]['AnomalyProbability'], float)
+
+    def test_lad_filtering_scoring_diff_order(self, scoring_test_data, lad_filtering_model):
+        import numpy as np
+        # check to see if scoring yields AdjustedActual with correct order of differences
+        pred_date_normal = scoring_test_data.index[0]
+        value_normal = scoring_test_data['raw'][0]
+        output_normal, lad_filtering_model_update = lad_filtering_model.score(value_normal, pred_date_normal)
+        # collect data
+        diff_order = output_normal["NonStationarityDiffOrder"]
+        adj_actual  = output_normal["AdjustedActual"]
+        last_points = lad_filtering_model._params['last_data_points']
+        last_points.append(value_normal)
+        # diff with model's diff_order
+        diff = np.diff(last_points, diff_order)[-1]
+
+        assert diff == adj_actual, f"AdjustedActual {adj_actual} does not match diff {diff_order} of last_data_points {last_points}"


### PR DESCRIPTION
Corrected issue where the diff order was hard coded as 2 in `lad_filtering`. Also added `test_lad_filtering_scoring_diff_order` to `test_models` which uses the last data points, takes the appropriate diff, and then compares to the adjusted actual to make sure the appropriate diff order is applied.

Related Issue: #120 
@sayanchk for review